### PR TITLE
Fix for single replacement of params

### DIFF
--- a/gulp-html-partial.js
+++ b/gulp-html-partial.js
@@ -104,8 +104,12 @@ module.exports = (function () {
      * @returns {String}
      */
     function replaceAttributes(file, attributes) {
-        return (attributes || []).reduce((html, attrObj) =>
-            html.replace(options.variablePrefix + attrObj.key, attrObj.value), file && file.toString() || '');
+        let html = file && file.toString() || '';
+        (attributes || []).forEach((attrib) => {
+            let regex = new RegExp(escapeRegExp(options.variablePrefix + attrib.key), 'g');
+            html = html.replace(regex, attrib.value);
+        });
+        return html;
     }
 
     /**
@@ -159,4 +163,14 @@ module.exports = (function () {
     }
 
     return transform;
+
+    /**
+     * Escapes characters for use in a regular expression
+     * @param {string} s String to escape
+     * @returns {string}
+     * @source https://stackoverflow.com/a/3561711/1267001
+     */
+    function escapeRegExp(s) {
+        return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+    }
 })();


### PR DESCRIPTION
This is a fix for #3 where using a variable more than once isn't replaced. The solution to this is to use javascript's global replace functionality, which requires using a regex with a global flag for finding the substring. I've added in a helper function from stack overflow to make sure that special characters in the variable are escaped. I've also pretty much rewritten the replaceAttributes function so it's a lot more readable (sorry, that's mostly personal preference since I can't understand comma operator statements to save my life).

Let me know if there's anything you'd like me to tweak to make it easier to add this to your project!
This is a great helper to me, since it's simple and does the job! Thanks!